### PR TITLE
Add printing with row offset and add TableSizeError

### DIFF
--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             ]),
         ],
         table_format,
-    );
+    )?;
     table.print_stdout()?;
     Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,11 +1,10 @@
-use std::io::Result;
-
 use cli_table::{
     format::{CellFormat, Justify},
     Cell, Row, Table,
 };
+use std::error::Error;
 
-fn main() -> Result<()> {
+fn main() -> std::result::Result<(), Box<dyn Error>> {
     let justify_right = CellFormat::builder().justify(Justify::Right).build();
     let bold = CellFormat::builder().bold(true).build();
 
@@ -29,7 +28,9 @@ fn main() -> Result<()> {
             ]),
         ],
         Default::default(),
-    );
+    )?;
 
-    table.print_stdout()
+    table.print_stdout()?;
+
+    Ok(())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,7 +10,7 @@ impl fmt::Display for TableSizeError {
     }
 }
 
-impl Error for TableSizeError { }
+impl Error for TableSizeError {}
 
 impl TableSizeError {
     pub fn new(message: &'static str) -> TableSizeError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,19 @@
+use core::fmt;
+use std::error::Error;
+
+#[derive(Debug)]
+pub struct TableSizeError(&'static str);
+
+impl fmt::Display for TableSizeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for TableSizeError { }
+
+impl TableSizeError {
+    pub fn new(message: &'static str) -> TableSizeError {
+        TableSizeError(message)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@
 mod cell;
 mod row;
 mod table;
+mod errors;
 
 pub mod format;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,9 +92,9 @@
 //! [`NO_BORDER_COLUMN_ROW`]: format/constant.NO_BORDER_COLUMN_ROW.html
 //! [`NO_BORDER_COLUMN_TITLE`]: format/constant.NO_BORDER_COLUMN_TITLE.html
 mod cell;
+mod errors;
 mod row;
 mod table;
-mod errors;
 
 pub mod format;
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -2,11 +2,11 @@ use std::io::{Result, Write};
 
 use termcolor::{BufferWriter, ColorChoice, WriteColor};
 
+use crate::errors::TableSizeError;
 use crate::{
     format::{HorizontalLine, TableFormat, VerticalLine},
     Row,
 };
-use crate::errors::TableSizeError;
 use std::error::Error;
 
 /// Struct for building a [`Table`](struct.Table.html) on command line
@@ -24,7 +24,7 @@ impl Table {
         validate_equal_columns(&rows)?;
         let widths = get_widths(&rows);
 
-        Ok( Table {
+        Ok(Table {
             rows,
             format,
             widths,
@@ -37,7 +37,11 @@ impl Table {
     }
 
     /// Prints table with an offset in Row number
-    pub fn print_stdout_with_offset(&self, row_offset: usize, number_to_print: usize) -> Result<()> {
+    pub fn print_stdout_with_offset(
+        &self,
+        row_offset: usize,
+        number_to_print: usize,
+    ) -> Result<()> {
         let relevant_rows = self.rows.iter().skip(row_offset).take(number_to_print);
         self.print_writer(relevant_rows, BufferWriter::stdout(ColorChoice::Always))
     }
@@ -47,7 +51,11 @@ impl Table {
         self.print_writer(self.rows.iter(), BufferWriter::stderr(ColorChoice::Always))
     }
 
-    fn print_writer<'a, I: std::iter::Iterator<Item = &'a Row>>(&self, rows_it: I, writer: BufferWriter) -> Result<()> {
+    fn print_writer<'a, I: std::iter::Iterator<Item = &'a Row>>(
+        &self,
+        rows_it: I,
+        writer: BufferWriter,
+    ) -> Result<()> {
         self.print_horizontal_line(&writer, self.format.border.top.as_ref())?;
 
         let mut rows = rows_it.peekable();
@@ -185,7 +193,7 @@ fn println_char(writer: &BufferWriter, c: char) -> Result<()> {
     Ok(())
 }
 
-fn validate_equal_columns(rows: &[Row]) -> std::result::Result<(), Box<dyn Error>>{
+fn validate_equal_columns(rows: &[Row]) -> std::result::Result<(), Box<dyn Error>> {
     if rows.len() <= 1 {
         return Ok(());
     }
@@ -193,7 +201,9 @@ fn validate_equal_columns(rows: &[Row]) -> std::result::Result<(), Box<dyn Error
 
     for row in rows.iter().skip(1) {
         if columns != row.columns() {
-            return Err(Box::new(TableSizeError::new("Mismatch column numbers in different rows")));
+            return Err(Box::new(TableSizeError::new(
+                "Mismatch column numbers in different rows",
+            )));
         }
     }
     Ok(())


### PR DESCRIPTION
Hi Devashish,

I've been playing arouund a bit more 🙂:

* I noticed a panic in one of the methods so created an error type to handle this. I'm not sure how you would like to structure these errors so I just put one in an `errors` module for the moment. It should prevent the panic, but it has also affected the public API as`Table::new` now returns a `Result`.

* I have altered the internal calls to the writers used during printing the tables to accept an iterator of Rows. This lets us only print a subset of the rows of the table. I have done this as a stepping-stone to eventually allowing paging of very large tables.

Let me know what you think!