### PR TITLE
add foreground to TableFormat

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
 use cli_table::{
-    format::{CellFormat, Justify, Padding},
+    format::{CellFormat, TableFormat, Color, Justify, Padding},
     Cell, Row, Table,
 };
 use std::error::Error;
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 Cell::new("25", justify_right),
             ]),
         ],
-        Default::default(),
+        TableFormat::default().foreground(Color::Red),
     )?;
 
     table.print_stdout()?;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,5 @@
 use cli_table::{
-    format::{CellFormat, TableFormat, Color, Justify, Padding},
+    format::{CellFormat, Color, Justify, Padding, TableFormat},
     Cell, Row, Table,
 };
 use std::error::Error;

--- a/src/format.rs
+++ b/src/format.rs
@@ -24,6 +24,7 @@ pub use self::table::{
 /// +------------+----------------+
 /// ```
 pub const BORDER_COLUMN_ROW: TableFormat = TableFormat {
+    foreground: None,
     border: Border {
         top: Some(HorizontalLine {
             left_end: '+',
@@ -64,6 +65,7 @@ pub const BORDER_COLUMN_ROW: TableFormat = TableFormat {
 /// +------------+----------------+
 /// ```
 pub const BORDER_COLUMN_TITLE: TableFormat = TableFormat {
+    foreground: None,
     border: Border {
         top: Some(HorizontalLine {
             left_end: '+',
@@ -103,6 +105,7 @@ pub const BORDER_COLUMN_TITLE: TableFormat = TableFormat {
 /// +------------+----------------+
 /// ```
 pub const BORDER_COLUMN_NO_ROW: TableFormat = TableFormat {
+    foreground: None,
     border: Border {
         top: Some(HorizontalLine {
             left_end: '+',
@@ -136,6 +139,7 @@ pub const BORDER_COLUMN_NO_ROW: TableFormat = TableFormat {
 ///  Scooby Doo |             25
 /// ```
 pub const NO_BORDER_COLUMN_TITLE: TableFormat = TableFormat {
+    foreground: None,
     border: Border {
         top: None,
         bottom: None,
@@ -166,6 +170,7 @@ pub const NO_BORDER_COLUMN_TITLE: TableFormat = TableFormat {
 ///  Scooby Doo |             25
 /// ```
 pub const NO_BORDER_COLUMN_ROW: TableFormat = TableFormat {
+    foreground: None,
     border: Border {
         top: None,
         bottom: None,
@@ -198,6 +203,7 @@ pub const NO_BORDER_COLUMN_ROW: TableFormat = TableFormat {
 /// +----------------------------+
 /// ```
 pub const BORDER_NO_COLUMN_ROW: TableFormat = TableFormat {
+    foreground: None,
     border: Border {
         top: Some(HorizontalLine {
             left_end: '+',

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -191,7 +191,11 @@ pub struct TableFormat {
 impl TableFormat {
     /// Creates a new instance of [`TableFormat`](struct.TableFormat.html)
     pub fn new(border: Border, separator: Separator) -> Self {
-        Self { border, separator, foreground: None }
+        Self {
+            border,
+            separator,
+            foreground: None
+        }
     }
 
     /// Set the foreground color of the table borders & separators.

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -1,3 +1,5 @@
+use termcolor::Color;
+
 /// A vertical line in a [`Table`](struct.Table.html) (border or column separator)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VerticalLine {
@@ -181,6 +183,7 @@ impl SeparatorBuilder {
 /// Struct for configuring a [`Table`](struct.Table.html)'s format
 #[derive(Debug, Default)]
 pub struct TableFormat {
+    pub(crate) foreground: Option<Color>,
     pub(crate) border: Border,
     pub(crate) separator: Separator,
 }
@@ -188,6 +191,12 @@ pub struct TableFormat {
 impl TableFormat {
     /// Creates a new instance of [`TableFormat`](struct.TableFormat.html)
     pub fn new(border: Border, separator: Separator) -> Self {
-        Self { border, separator }
+        Self { border, separator, foreground: None }
+    }
+
+    /// Set the foreground color of the table borders & separators.
+    pub fn foreground(mut self, color: Color) -> Self {
+        self.foreground = Some(color);
+        self
     }
 }

--- a/src/format/table.rs
+++ b/src/format/table.rs
@@ -194,7 +194,7 @@ impl TableFormat {
         Self {
             border,
             separator,
-            foreground: None
+            foreground: None,
         }
     }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use termcolor::{BufferWriter, ColorChoice, WriteColor};
+use termcolor::{BufferWriter, ColorSpec, Color, ColorChoice, WriteColor};
 
 use crate::{
     format::{HorizontalLine, TableFormat, VerticalLine},
@@ -56,9 +56,9 @@ impl Table {
                 let mut line_buffers = line.into_iter().peekable();
 
                 while let Some(buffer) = line_buffers.next() {
-                    print_char(&writer, ' ')?;
+                    print_char(&writer, ' ', None)?;
                     writer.print(&buffer)?;
-                    print_char(&writer, ' ')?;
+                    print_char(&writer, ' ', None)?;
 
                     match line_buffers.peek() {
                         Some(_) => self
@@ -69,7 +69,7 @@ impl Table {
                     }
                 }
 
-                println_str(&writer, "")?;
+                println_str(&writer, "", None)?;
             }
 
             match rows.peek() {
@@ -103,7 +103,7 @@ impl Table {
     ) -> io::Result<()> {
         if let Some(line) = line {
             if self.format.border.left.is_some() {
-                print_char(writer, line.left_end)?;
+                print_char(writer, line.left_end, self.format.foreground)?;
             }
 
             let mut widths = self.widths.iter().peekable();
@@ -112,19 +112,19 @@ impl Table {
                 let s = std::iter::repeat(line.filler)
                     .take(width + 2)
                     .collect::<String>();
-                print_str(writer, &s)?;
+                print_str(writer, &s, self.format.foreground)?;
 
                 match widths.peek() {
                     Some(_) => {
                         if self.format.separator.column.is_some() {
-                            print_char(writer, line.junction)?
+                            print_char(writer, line.junction, self.format.foreground)?
                         }
                     }
                     None => {
                         if self.format.border.right.is_some() {
-                            println_char(writer, line.right_end)?;
+                            println_char(writer, line.right_end, self.format.foreground)?;
                         } else {
-                            println_str(writer, "")?;
+                            println_str(writer, "", self.format.foreground)?;
                         }
                     }
                 }
@@ -140,39 +140,43 @@ impl Table {
         line: Option<&VerticalLine>,
     ) -> io::Result<()> {
         if let Some(line) = line {
-            print_char(writer, line.filler)?;
+            print_char(writer, line.filler, self.format.foreground)?;
         }
         Ok(())
     }
 }
 
-fn print_str(writer: &BufferWriter, s: &str) -> io::Result<()> {
+fn print_str(writer: &BufferWriter, s: &str, foreground: Option<Color>) -> io::Result<()> {
     let mut buffer = writer.buffer();
     buffer.reset()?;
+    buffer.set_color(&ColorSpec::default().set_fg(foreground))?;
     write!(&mut buffer, "{}", s)?;
     writer.print(&buffer)?;
     Ok(())
 }
 
-fn println_str(writer: &BufferWriter, s: &str) -> io::Result<()> {
+fn println_str(writer: &BufferWriter, s: &str, foreground: Option<Color>) -> io::Result<()> {
     let mut buffer = writer.buffer();
     buffer.reset()?;
+    buffer.set_color(&ColorSpec::default().set_fg(foreground))?;
     writeln!(&mut buffer, "{}", s)?;
     writer.print(&buffer)?;
     Ok(())
 }
 
-fn print_char(writer: &BufferWriter, c: char) -> io::Result<()> {
+fn print_char(writer: &BufferWriter, c: char, foreground: Option<Color>) -> io::Result<()> {
     let mut buffer = writer.buffer();
     buffer.reset()?;
+    buffer.set_color(&ColorSpec::default().set_fg(foreground))?;
     write!(&mut buffer, "{}", c)?;
     writer.print(&buffer)?;
     Ok(())
 }
 
-fn println_char(writer: &BufferWriter, c: char) -> io::Result<()> {
+fn println_char(writer: &BufferWriter, c: char, foreground: Option<Color>) -> io::Result<()> {
     let mut buffer = writer.buffer();
     buffer.reset()?;
+    buffer.set_color(&ColorSpec::default().set_fg(foreground))?;
     writeln!(&mut buffer, "{}", c)?;
     writer.print(&buffer)?;
     Ok(())

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use termcolor::{BufferWriter, ColorSpec, Color, ColorChoice, WriteColor};
+use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 use crate::{
     format::{HorizontalLine, TableFormat, VerticalLine},


### PR DESCRIPTION
I renamed the color field i spoke of in #8 to 'foreground' to be consistent with CellFormat, though i left of the '_color' because it seemed unnecessary. 