### PR TITLE
Avoid unwrapping when titled table is empty

### DIFF
--- a/cli-table/src/table.rs
+++ b/cli-table/src/table.rs
@@ -106,7 +106,9 @@ impl TableStruct {
         )?;
 
         if let Some(ref title) = self.title {
-            let title_dimension = row_dimensions.next().unwrap();
+            let title_dimension = row_dimensions
+                .next()
+                .unwrap_or_else(|| title.required_dimension());
             title.print_writer(&writer, title_dimension, &self.format, &color_spec)?;
 
             if self.format.separator.title.is_some() {


### PR DESCRIPTION
Hey, how you doing :)

This fixes an issue that happens when creating a titled table without any rows.
In that case a `next()` would return `None`