### PR TITLE
Remove unused import in 2nd README.md example

### DIFF
--- a/cli-table/README.md
+++ b/cli-table/README.md
@@ -56,7 +56,7 @@ To get a `Display` trait implementation of `TableStruct`, use `display()` functi
 of `TableDisplay` which implements `Display` trait.
 
 ```rust
-use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
+use cli_table::{format::Justify, Cell, Style, Table};
 
 let table = vec![
     vec!["Tom".cell(), 10.cell().justify(Justify::Right)],

--- a/cli-table/src/lib.rs
+++ b/cli-table/src/lib.rs
@@ -53,7 +53,7 @@
 //! of `TableDisplay` which implements `Display` trait.
 //!
 //! ```rust
-//! use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
+//! use cli_table::{format::Justify, Cell, Style, Table};
 //!
 //! let table = vec![
 //!     vec!["Tom".cell(), 10.cell().justify(Justify::Right)],


### PR DESCRIPTION
Minor detail: the import line for the 2nd usage example was likely copy/pasted, `print_stdout` is unused in the 2nd example.

Just started using this crate, love the API.