### PR TITLE
include license files in published crates

### DIFF
--- a/cli-table-derive/Cargo.toml
+++ b/cli-table-derive/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/devashishdxt/cli-table"
 categories = ["command-line-interface"]
 keywords = ["table", "cli", "format"]
 readme = "README.md"
-include = ["Cargo.toml", "src/**/*.rs", "README.md"]
+include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-*"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cli-table-derive/LICENSE-APACHE
+++ b/cli-table-derive/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/cli-table-derive/LICENSE-MIT
+++ b/cli-table-derive/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/cli-table/Cargo.toml
+++ b/cli-table/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/devashishdxt/cli-table"
 categories = ["command-line-interface"]
 keywords = ["table", "cli", "format"]
 readme = "README.md"
-include = ["Cargo.toml", "src/**/*.rs", "README.md"]
+include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-*"]
 edition = "2018"
 
 [lib]

--- a/cli-table/LICENSE-APACHE
+++ b/cli-table/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/cli-table/LICENSE-MIT
+++ b/cli-table/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Both the MIT and Apache-2.0 licenses require that redistributed sources contain a copy of the original license text. This currently isn't the case for the cli-table and cli-table-derive crates published on crates.io, which creates a problem for users that need to care about license compliance (for example, I'm looking into adding packages for these two crates to Fedora Linux as a dependency of juliaup).